### PR TITLE
ACF JSON: Fix wrong relative path

### DIFF
--- a/includes/helper.php
+++ b/includes/helper.php
@@ -37,31 +37,31 @@ if(!function_exists('viivue_get_icomoon_json_path')){
 			}
 			
 			// If the json_path is relative, we need to find the full path
-			// for example [your-theme]/assets/fonts/selection.json or wp-content/themes/[your-theme]/assets/fonts/selection.json
 			$array_json_path     = explode('/', $json_path);
 			$json_path_separator = viivue_array_key_exists(0, $array_json_path);
 			if($json_path_separator){
+				// for example [your-theme]/assets/fonts/selection.json or wp-content/themes/[your-theme]/assets/fonts/selection.json
 				$position = strpos($theme_path, $json_path_separator);
 				if($position !== false){
 					$json_path = substr($theme_path, 0, $position) . $json_path;
 					if(file_exists($json_path)){
 						return $json_path;
 					}
+				}else{
+					// for example assets/fonts/selection.json
+					$json_path = $theme_path . '/' . $json_path;
+					if(file_exists($json_path)){
+						return $json_path;
+					}
 				}
 			}
-			
-			// Fallback to search and return any selection.json from theme
-			$folder_path   = viivue_array_key_exists('dirname', pathinfo(get_template_directory()));
-			$recursive_dir = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($folder_path));
-			$filename      = viivue_array_key_exists('basename', pathinfo($json_path));
-			foreach($recursive_dir as $file){
-				if($file->getBasename() == $filename){
-					return $file->getPathname();
-				}
-			}
+		}else{
+			// If no json_path is provided, return the default selection.json path
+			// from wp-content/themes/[your-theme]/assets/fonts/selection.json
+			$json_path = viivue_acf_icomoon_default_json_option();
 		}
 		
-		return viivue_acf_icomoon_default_json_option();
+		return $json_path;
 	}
 }
 


### PR DESCRIPTION
- The previous code doens't work when JSON path has duplicated folder names (it causes the wrong path).
- Improve the JSON relative path with the correct solution: Search and concat the path instead of handling the path with array.