### PR TITLE
WPBakery Page Builder: Fix wrong json path in icomoon_class param

### DIFF
--- a/compatibility/js_composer.php
+++ b/compatibility/js_composer.php
@@ -12,8 +12,8 @@ function viivue_js_composer_icomoon($settings, $value){
 	$icon_array = $acf_icomoon->viivue_get_icomoon_json($json_path);
 	$type       = viivue_array_key_exists("type", $settings);
 	$param_name = viivue_array_key_exists("param_name", $settings);
-	$value      = esc_attr($value);
 	$param_name = esc_attr($param_name);
+	$value      = esc_attr($value);
 	$input_html = '<input name="' . $param_name . '" class="hidden wpb_vc_param_value wpb-textinput ' . $param_name . ' ' . esc_attr($type) . '_field" type="text" v-model="selected.icon_class" data-icomoon-input/>';
 	
 	$html = $acf_icomoon->viivue_icomoon_select_html($icon_array, $value, $input_html, true);


### PR DESCRIPTION
- Fix wrong icon JSON path that used for the icomoon param in VC.
- Create new filter `viivue_vc_icomoon_json_path` to update path using hook.