### PR TITLE
WordPress 6.8.1: Remove notices

### DIFF
--- a/includes/fields/acf-field-icomoon.php
+++ b/includes/fields/acf-field-icomoon.php
@@ -36,7 +36,7 @@ if(!class_exists('ViiVue_ACF_Field_Icomoon')){
 		 */
 		public function __construct(){
 			$this->name     = 'viivue_acf_icomoon';
-			$this->label    = __('Icomoon', 'acf-icomoon');
+			$this->label    = 'Icomoon';
 			$this->category = 'content';
 			$this->defaults = [
 				'selection_json_path' => viivue_acf_icomoon_default_json_option(),


### PR DESCRIPTION
Fix issue **Function _load_textdomain_just_in_time was called incorrectly** on WordPress 6.8.1